### PR TITLE
create github-actions publish and release workflows

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,47 @@
+name: Create Release
+on: workflow_dispatch
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          architecture: x64
+
+      - name: Set up Git
+        run: |
+          git config --global user.name ${{ secrets.GIT_USERNAME }}
+          git config --global user.email ${{ secrets.GIT_USEREMAIL }}
+      
+      - name: Prepare release
+        run: |
+          mvn -B clean release:prepare -f pom.release.xml \
+          -Dgithub_username=${{ secrets.GIT_USERNAME }} \
+          -Dgithub_token=${{ secrets.GITHUB_TOKEN }} \
+          -Dgithub_owner=${{ github.repository_owner }} \
+          -Dgithub_owner_repo=${{ github.repository }}
+
+      - name: Perform release
+        run: |
+          mvn -B release:perform -f pom.release.xml \
+          -Dgithub_username=${{ secrets.GIT_USERNAME }} \
+          -Dgithub_token=${{ secrets.GITHUB_TOKEN }} \
+          -Dgithub_owner=${{ github.repository_owner }} \
+          -Dgithub_owner_repo=${{ github.repository }} \
+          -Darguments="-Dgithub_owner_repo=${{ github.repository }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean temporary files
+        run: mvn -B release:clean

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,5 +1,15 @@
 name: Create Release
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      releaseVersionOverride:
+        description: "Release version override"
+        required: false
+        default: ''
+      developmentVersionOverride:
+        description: "Next development version override"
+        required: false
+        default: ''
 
 jobs:
   create-release:
@@ -24,17 +34,28 @@ jobs:
           git config --global user.name ${{ secrets.GIT_USERNAME }}
           git config --global user.email ${{ secrets.GIT_USEREMAIL }}
       
+      - name: Override versions
+        run: |
+          test ! -z "${{ github.event.inputs.releaseVersionOverride }}"  && \
+          echo 'RELEASE_VERSION_OVERRIDE=-DreleaseVersion="${{ github.event.inputs.releaseVersionOverride }}"' >> $GITHUB_ENV || \
+          echo "releaseVersionOverride is not set, use default release version"
+          test ! -z "${{ github.event.inputs.developmentVersionOverride }}" && \
+          echo 'DEVELOPMENT_VERSION_OVERRIDE=-DdevelopmentVersion="${{ github.event.inputs.developmentVersionOverride }}"' >> $GITHUB_ENV || \
+          echo "developmentVersionOverride is not set, use default development version"
+
       - name: Prepare release
         run: |
-          mvn -B clean release:prepare -f pom.release.xml \
+          mvn -B clean release:prepare \
           -Dgithub_username=${{ secrets.GIT_USERNAME }} \
           -Dgithub_token=${{ secrets.GITHUB_TOKEN }} \
           -Dgithub_owner=${{ github.repository_owner }} \
-          -Dgithub_owner_repo=${{ github.repository }}
+          -Dgithub_owner_repo=${{ github.repository }} \
+          ${{ env.RELEASE_VERSION_OVERRIDE }} \
+          ${{ env.DEVELOPMENT_VERSION_OVERRIDE }}
 
       - name: Perform release
         run: |
-          mvn -B release:perform -f pom.release.xml \
+          mvn -B release:perform \
           -Dgithub_username=${{ secrets.GIT_USERNAME }} \
           -Dgithub_token=${{ secrets.GITHUB_TOKEN }} \
           -Dgithub_owner=${{ github.repository_owner }} \

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -1,0 +1,25 @@
+name: Build and Publish to Maven
+on: workflow_dispatch
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          architecture: x64
+        
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn -B deploy -Dgithub_owner_repo=${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>enclave-attestation-api</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Interfaces for enclave attestation process</description>
@@ -15,10 +15,7 @@
         <image.version>${project.version}</image.version>
     </properties>
 
-    <dependencies>
-
-    </dependencies>
-
+    <dependencies />
 
     <build>
         <plugins>
@@ -67,6 +64,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
         </plugins>
     </build>
+
+
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>https://${github_username}:${github_token}@github.com/${github_owner_repo}.git</url>
+        <tag>enclave-attestation-api-0.0.8</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub ${github_owner} Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/${github_owner_repo}</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://${github_username}:${github_token}@github.com/${github_owner_repo}.git</url>
-        <tag>enclave-attestation-api-0.0.8</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Created 2 workflows
1. Build and Publish to Maven
- manually triggered
- build and publish a snapshot artifacts to GitHub Packages of the owner/repo

2. Create Release
- manually triggered
- creates a release branch and push
- increment snapshot version on current branch (supposedly main/master)
- build and publish release artifacts from the release branch to GitHub Packages

To create release, your github repository should have secrets.GIT_USERNAME and secrets.GIT_USEREMAIL configured. They are for git to automatically create release branch.